### PR TITLE
Add semgrep workflow to CI pipeline, for real this time

### DIFF
--- a/.github/workflows/semgrep-analysis.yaml
+++ b/.github/workflows/semgrep-analysis.yaml
@@ -1,0 +1,48 @@
+# This workflow file requires a free account on Semgrep.dev to
+# manage rules, file ignores, notifications, and more.
+#
+# See https://semgrep.dev/docs
+
+name: Semgrep
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: [master, '*.*']
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master, '*.*']
+
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    steps:
+    # Checkout project source
+    - uses: actions/checkout@v2
+
+    # Scan code using project's configuration on https://semgrep.dev/manage
+    - uses: returntocorp/semgrep-action@v1
+      with:
+        # publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
+        # publishDeployment: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
+        # generateSarif: '1'
+        config: >-
+          p/ci
+          p/command-injection
+          p/insecure-transport
+          p/owasp-top-ten
+          p/python
+          p/r2c
+          p/r2c-best-practices
+          p/r2c-bug-scan
+          p/r2c-ci
+          p/security-audit
+          p/secrets
+
+
+      # Upload SARIF file generated in previous step
+      # - name: Upload SARIF file
+      #   uses: github/codeql-action/upload-sarif@v1
+      #   with:
+      #     sarif_file: semgrep.sarif
+      #   if: always()

--- a/src/submanager/config/lock.py
+++ b/src/submanager/config/lock.py
@@ -111,7 +111,7 @@ def wait_for_lock(
                 f"retrying for {timeout_s} s...",
             )
             first_attempt = False
-        time.sleep(check_interval_s)
+        time.sleep(check_interval_s)  # nosemgrep
 
     if not raise_error_on_timeout:
         return False

--- a/src/submanager/core/commands.py
+++ b/src/submanager/core/commands.py
@@ -6,7 +6,7 @@ from __future__ import (
 )
 
 # Standard library imports
-import importlib.resources
+import importlib.resources  # nosemgrep
 import sys
 from pathlib import (
     Path,

--- a/src/submanager/thread/creation.py
+++ b/src/submanager/thread/creation.py
@@ -147,7 +147,7 @@ def handle_pin_thread(
     # Unpin previous thread if not in auto pin mode
     if not auto and thread_context_mod.current_thread:
         thread_context_mod.current_thread.mod.sticky(state=False)
-        time.sleep(2)
+        time.sleep(2)  # nosemgrep
 
     # Get currently pinned threads
     current_pins: list[praw.models.reddit.submission.Submission] = []

--- a/src/submanager/validation/connection.py
+++ b/src/submanager/validation/connection.py
@@ -13,6 +13,9 @@ from typing import (
 # Third party imports
 import requests
 import requests.exceptions
+from typing_extensions import (
+    Final,
+)
 
 # Local imports
 import submanager.exceptions
@@ -20,6 +23,8 @@ from submanager.constants import (
     REDDIT_BASE_URL,
     USER_AGENT,
 )
+
+REQUEST_TIMEOUT_S: Final[float] = 5
 
 
 def get_reddit_oauth_scopes(
@@ -39,6 +44,7 @@ def get_reddit_oauth_scopes(
         scopes_endpoint_url,
         params=query_params,
         headers=headers,
+        timeout=REQUEST_TIMEOUT_S,
     )
     response.raise_for_status()
     response_json: dict[str, dict[str, str]] = response.json()

--- a/tools/generate_requirements_files.py
+++ b/tools/generate_requirements_files.py
@@ -99,7 +99,7 @@ def generate_requirements_files(
             output_filename,
             *extra_args,
         ]
-        pip_compile_result = subprocess.run(
+        pip_compile_result = subprocess.run(  # nosemgrep
             pip_compile_invocation,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
Semgrep didn't actually run over the whole repo in the previous are, so the outstanding issues went unreported, per  returntocorp/semgrep-action#352 . This PR is a redo of #3 to commit both adding semgrep and fixing its issues in one clean, passing-build, atomic commit.