### PR TITLE
Update CIs following v0.6.0 release and test changes in new Mega-Linter preview release

### DIFF
--- a/.github/workflows/mega-linter.yaml
+++ b/.github/workflows/mega-linter.yaml
@@ -41,7 +41,7 @@ jobs:
       id: ml
       # You can override Mega-Linter flavor used to have faster performance
       # More info at https://megalinter.github.io/flavors/
-      uses: megalinter/megalinter/flavors/python@v5
+      uses: megalinter/megalinter/flavors/python@beta
       env:
         # All available variables are described in documentation
         # https://megalinter.github.io/configuration/

--- a/.github/workflows/mega-linter.yaml
+++ b/.github/workflows/mega-linter.yaml
@@ -1,5 +1,5 @@
 # Mega-Linter GitHub Action configuration file
-# More info at https://nvuillam.github.io/mega-linter
+# More info at https://megalinter.github.io
 name: Mega-Linter
 
 on:  # yamllint disable-line rule:truthy
@@ -20,16 +20,11 @@ permissions:
   pull-requests: write
   statuses: write
 
-jobs:
-  # Cancel duplicate jobs: https://github.com/fkirc/skip-duplicate-actions#option-3-cancellation-only
-  cancel_duplicates:
-    name: Cancel duplicate jobs
-    runs-on: ubuntu-latest
-    steps:
-    - uses: fkirc/skip-duplicate-actions@master
-      with:
-        github_token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
 
+jobs:
   build:
     name: Mega-Linter
     runs-on: ubuntu-latest
@@ -45,11 +40,11 @@ jobs:
     - name: Mega-Linter
       id: ml
       # You can override Mega-Linter flavor used to have faster performance
-      # More info at https://nvuillam.github.io/mega-linter/flavors/
-      uses: nvuillam/mega-linter/flavors/python@v4
+      # More info at https://megalinter.github.io/flavors/
+      uses: megalinter/megalinter/flavors/python@v5
       env:
         # All available variables are described in documentation
-        # https://nvuillam.github.io/mega-linter/configuration/
+        # https://megalinter.github.io/configuration/
         VALIDATE_ALL_CODEBASE: true  # Set ${{ github.event_name == &#39;push&#39; &amp;&amp; github.ref == &#39;refs/heads/master&#39; }} to validate only diff with master branch
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # ADD YOUR CUSTOM ENV VARIABLES HERE TO OVERRIDE VALUES OF .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,5 +1,5 @@
 # Configuration file for Mega-Linter
-# See all available variables at https://nvuillam.github.io/mega-linter/configuration/ and in linters documentation
+# See all available variables at https://megalinter.github.io/configuration/ and in linters documentation
 
 # ENABLE:  # If you use ENABLE variable, all other languages/formats/tooling-formats will be disabled by default
 # ENABLE_LINTERS:  # If you use ENABLE_LINTERS variable, all other linters will be disabled by default

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -8,8 +8,6 @@
 # - SPELL  # Uncomment to disable checks of spelling mistakes
 DISABLE_LINTERS:
 - MARKDOWN_MARKDOWN_TABLE_FORMATTER  # Unable to locally autoformat tables
-- PYTHON_BANDIT  # Unable to set to use repo config file; re-enable when fixed
-- PYTHON_BLACK  # Version in Mega-Linter doesn't yet support Python 3.9
 - PYTHON_MYPY  # Managed externally; relies on locally installed packages
 - PYTHON_PYLINT  # Managed externally; relies on locally installed packages
 - SPELL_CSPELL  # Vast number of false positives
@@ -22,9 +20,12 @@ FORMATTERS_DISABLE_ERRORS: false
 SHOW_ELAPSED_TIME: true
 
 MARKDOWN_MARKDOWNLINT_CONFIG_FILE: LINTER_DEFAULT
-# PYTHON_BANDIT_CONFIG_FILE: LINTER_DEFAULT  # Uncomment when Bandit config supported
+PYTHON_BANDIT_CLI_LINT_MODE: project  # For testing
+PYTHON_BANDIT_CONFIG_FILE: .bandit.yml  # Explicitly specify so Bandit works
 PYTHON_BLACK_CONFIG_FILE: LINTER_DEFAULT
 PYTHON_FLAKE8_CONFIG_FILE: LINTER_DEFAULT
 PYTHON_ISORT_CONFIG_FILE: LINTER_DEFAULT
 YAML_PRETTIER_CONFIG_FILE: LINTER_DEFAULT
 YAML_YAMLLINT_CONFIG_FILE: LINTER_DEFAULT
+
+LOG_LEVEL: DEBUG  # Temporarily added to debug mega-linter

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 <!-- Things used -->
-[![PyPI Python version](https://img.shields.io/pypi/pyversions/submanager?label=Python)](https://pypi.org/project/submanager/)  <!-- markdown-link-check-disable-line -->
+[![PyPI Python version](https://img.shields.io/pypi/pyversions/submanager?label=Python)](https://pypi.org/project/submanager/)
 [![Framework](https://img.shields.io/badge/Framework-PRAW-orange.svg)](https://github.com/pytest-dev/pytest)
 [![Tests Pytest](https://img.shields.io/badge/Testing-Pytest-blue.svg)](https://pytest.org/)
 [![Pre-Commit](https://img.shields.io/badge/Linting-Pre--Commit-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
@@ -12,10 +12,10 @@
 <!-- Project status -->
 [![License](https://img.shields.io/github/license/r-spacex/submanager?label=License)](https://github.com/r-spacex/submanager/blob/master/LICENSE.txt)
 [![Maintainer](https://img.shields.io/badge/Maintainer-CAM--Gerlach-blue)](https://github.com/CAM-Gerlach)
-[![PyPI status](https://img.shields.io/pypi/status/submanager?label=Status)](https://pypi.org/project/submanager/)  <!-- markdown-link-check-disable-line -->
+[![PyPI status](https://img.shields.io/pypi/status/submanager?label=Status)](https://pypi.org/project/submanager/)
 [![GitHub version](https://img.shields.io/github/v/tag/r-spacex/submanager?include_prereleases&label=GitHub)](https://github.com/r-spacex/submanager/releases)
-[![PyPI version](https://img.shields.io/pypi/v/submanager?label=PyPI)](https://pypi.org/project/submanager/)  <!-- markdown-link-check-disable-line -->
-[![PyPI wheel](https://img.shields.io/pypi/wheel/submanager?label=Wheel)](https://pypi.org/project/submanager/)  <!-- markdown-link-check-disable-line -->
+[![PyPI version](https://img.shields.io/pypi/v/submanager?label=PyPI)](https://pypi.org/project/submanager/)
+[![PyPI wheel](https://img.shields.io/pypi/wheel/submanager?label=Wheel)](https://pypi.org/project/submanager/)
 [![Subreddit subscribers](https://img.shields.io/reddit/subreddit-subscribers/spacex?label=Subs)](https://www.reddit.com/r/spacex/)
 
 <!-- Build status -->
@@ -88,7 +88,7 @@ Of course, you're free to use any environment management tool of your choice (co
 
 ### Download and install
 
-To download and install the package from the [Python Package Index (PyPI)](https://pypi.org/project/submanager/), simply activate your environment and run  <!-- markdown-link-check-disable-line -->
+To download and install the package from the [Python Package Index (PyPI)](https://pypi.org/project/submanager/), simply activate your environment and run
 
 ```bash
 python -m pip install submanager


### PR DESCRIPTION
* [x] Remove link check disables for PyPI links that didn't work yet
* [x] Re-enable Bandit and Black on Mega-Linter following fixing blocking Mega-Linter issues with those linters
* [ ] Bump pre-commit and dep versions
* [ ] Port improvements from spyder-docs
* [ ] Add support for Python 3.10 to matrix and setup.cfg
* [ ] Consider re-basing to 0.6.x?
* [ ] (Fixup to switch back to production Mega-Linter once CIs pass and the new build is live)

Mega linter blocking issues reference: Bandit nvuillam/mega-linter#679 and Black nvuillam/mega-linter#681 , both in nvuillam/mega-linter#682